### PR TITLE
Clickhouse 0.7 Fix alter table operation bug

### DIFF
--- a/catalogs/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operation/ClickHouseTableOperations.java
+++ b/catalogs/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operation/ClickHouseTableOperations.java
@@ -178,7 +178,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
           .append(column.name())
           .append(BACK_QUOTE);
 
-      appendColumnDefinition(column, sqlBuilder, false);
+      appendColumnDefinition(column, sqlBuilder);
       // Add a comma for the next column, unless it's the last one
       if (i < columns.length - 1) {
         sqlBuilder.append(",\n");
@@ -439,7 +439,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
         + BACK_QUOTE
         + col
         + BACK_QUOTE
-        + appendColumnDefinition(updateColumn, new StringBuilder(), true);
+        + appendColumnDefinition(updateColumn, new StringBuilder());
   }
 
   @VisibleForTesting
@@ -472,7 +472,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
         + BACK_QUOTE
         + col
         + BACK_QUOTE
-        + appendColumnDefinition(updateColumn, new StringBuilder(), true);
+        + appendColumnDefinition(updateColumn, new StringBuilder());
   }
 
   private String generateAlterTableProperties(List<TableChange.SetProperty> setProperties) {
@@ -509,7 +509,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
         + BACK_QUOTE
         + col
         + BACK_QUOTE
-        + appendColumnDefinition(updateColumn, new StringBuilder(), true);
+        + appendColumnDefinition(updateColumn, new StringBuilder());
   }
 
   private String addColumnFieldDefinition(TableChange.AddColumn addColumn) {
@@ -613,7 +613,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
     StringBuilder columnDefinition = new StringBuilder();
     columnDefinition.append(MODIFY_COLUMN).append(quote(col));
-    appendColumnDefinition(column, columnDefinition, true);
+    appendColumnDefinition(column, columnDefinition);
     if (updateColumnPosition.getPosition() instanceof TableChange.First) {
       columnDefinition.append("FIRST");
     } else if (updateColumnPosition.getPosition() instanceof TableChange.After) {
@@ -666,7 +666,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
             .withComment(column.comment())
             .withDefaultValue(updateColumnDefaultValue.getNewDefaultValue())
             .build();
-    return appendColumnDefinition(newColumn, sqlBuilder, true).toString();
+    return appendColumnDefinition(newColumn, sqlBuilder).toString();
   }
 
   private String updateColumnTypeFieldDefinition(
@@ -686,23 +686,19 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
             .withNullable(column.nullable())
             .withAutoIncrement(column.autoIncrement())
             .build();
-    return appendColumnDefinition(newColumn, sqlBuilder, true).toString();
+    return appendColumnDefinition(newColumn, sqlBuilder).toString();
   }
 
-  private StringBuilder appendColumnDefinition(
-      JdbcColumn column, StringBuilder sqlBuilder, boolean isUpdateCol) {
-
+  private StringBuilder appendColumnDefinition(JdbcColumn column, StringBuilder sqlBuilder) {
     // Add Nullable data type
     String dataType=typeConverter.fromGravitino(column.dataType());
-    if (!isUpdateCol) {
-      if (column.nullable()) {
-        sqlBuilder.append(SPACE).append("Nullable(").append(dataType).append(")").append(SPACE);
-      } else {
-        sqlBuilder.append(SPACE).append(dataType).append(SPACE);
-      }
+    if (column.nullable()) {
+      sqlBuilder.append(SPACE).append("Nullable(").append(dataType).append(")").append(SPACE);
+    } else {
+      sqlBuilder.append(SPACE).append(dataType).append(SPACE);
     }
     
-    //     ck no support alter table with set nullable
+    // ck no support alter table with set nullable
 
     // Add DEFAULT value if specified
     if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {
@@ -713,9 +709,9 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
     }
 
     // Add column auto_increment if specified
-    if (column.autoIncrement()) {
-      sqlBuilder.append(CLICKHOUSE_AUTO_INCREMENT).append(" ");
-    }
+//    if (column.autoIncrement()) {
+//      sqlBuilder.append(CLICKHOUSE_AUTO_INCREMENT).append(" ");
+//    }
 
     // Add column comment if specified
     if (StringUtils.isNotEmpty(column.comment())) {

--- a/catalogs/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operation/ClickHouseTableOperations.java
+++ b/catalogs/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operation/ClickHouseTableOperations.java
@@ -691,17 +691,18 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
 
   private StringBuilder appendColumnDefinition(
       JdbcColumn column, StringBuilder sqlBuilder, boolean isUpdateCol) {
-    // Add data type
-    sqlBuilder.append(SPACE).append(typeConverter.fromGravitino(column.dataType())).append(SPACE);
 
-    //     ck no support alter table with set nullable
+    // Add Nullable data type
+    String dataType=typeConverter.fromGravitino(column.dataType());
     if (!isUpdateCol) {
       if (column.nullable()) {
-        sqlBuilder.append("NULL ");
+        sqlBuilder.append(SPACE).append("Nullable(").append(dataType).append(")").append(SPACE);
       } else {
-        sqlBuilder.append("NOT NULL ");
+        sqlBuilder.append(SPACE).append(dataType).append(SPACE);
       }
     }
+    
+    //     ck no support alter table with set nullable
 
     // Add DEFAULT value if specified
     if (!DEFAULT_VALUE_NOT_SET.equals(column.defaultValue())) {

--- a/catalogs/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operation/ClickHouseTableOperations.java
+++ b/catalogs/catalog-jdbc-clickhouse/src/main/java/org/apache/gravitino/catalog/clickhouse/operation/ClickHouseTableOperations.java
@@ -550,17 +550,17 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
       columnDefinition.append(CLICKHOUSE_AUTO_INCREMENT).append(SPACE);
     }
 
-    // Append comment if available
-    if (StringUtils.isNotEmpty(addColumn.getComment())) {
-      columnDefinition.append("COMMENT '").append(addColumn.getComment()).append("' ");
-    }
-
     // Append default value if available
     if (!Column.DEFAULT_VALUE_NOT_SET.equals(addColumn.getDefaultValue())) {
       columnDefinition
           .append("DEFAULT ")
           .append(columnDefaultValueConverter.fromGravitino(addColumn.getDefaultValue()))
           .append(SPACE);
+    }
+
+    //Append comment if available after default value
+    if (StringUtils.isNotEmpty(addColumn.getComment())) {
+      columnDefinition.append("COMMENT '").append(addColumn.getComment()).append("' ");
     }
 
     // Append position if available
@@ -578,6 +578,7 @@ public class ClickHouseTableOperations extends JdbcTableOperations {
     } else {
       throw new IllegalArgumentException("Invalid column position.");
     }
+
     return columnDefinition.toString();
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

1. fix sql Syntax error：Alter table column statement, put comment after the default clause
2. fix updateColumnNullability():  changes the data type of the column whether Nullable (dataType)
3. method appendColumnDefinition(): Remove the isUpdateCol parameter

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?


### How was this patch tested?

